### PR TITLE
Add 'Group.Read.All' scope to MS Groups

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -285,7 +285,7 @@ SERVICES = [
         'display': 'Microsoft Office 365 Groups (Microsoft Graph API)',
         'type': 'msgraph',
         'id': 'msgroup',
-        'scope': 'offline_access Files.ReadWrite.All	',
+        'scope': 'offline_access Files.ReadWrite.All Group.Read.All',
         'servicelink': 'https://support.office.com/en-us/article/Learn-about-Office-365-groups-b565caa1-5c40-40ef-9915-60fdb2d97fa2',
         'notes': '<p style="font-size: small">By using the OAuth login service for OneDrive you agree to the <a href="https://www.microsoft.com/en-us/servicesagreement" target="_blank">Microsoft Service Agreement</a> and <a href="https://privacy.microsoft.com/en-us/privacystatement" target="_blank">Microsoft Online Privacy Statement</a></p>'
     },


### PR DESCRIPTION
(turns out it is needed to lookup group IDs by email address)