### PR TITLE
Added support for Jottacloud cli token

### DIFF
--- a/cli-token.html
+++ b/cli-token.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>{{longappname}}</title>
+
+    <link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.2.0/css/bootstrap.min.css">
+    <link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.2.0/css/bootstrap-theme.min.css">
+
+    <script src="//ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
+    <script src="//maxcdn.bootstrapcdn.com/bootstrap/3.2.0/js/bootstrap.min.js"></script>
+
+    <!-- HTML5 Shim and Respond.js IE8 support of HTML5 elements and media queries -->
+    <!--[if lt IE 9]>
+      <script src="//oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
+      <script src="//oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
+    <![endif]-->
+  </head>
+  <body>
+    <div class="jumbotron">
+      <h1>{{appname}} for {{service}}</h1>
+
+      <p>Type in the CLI token</p>
+      <form action="/cli-token-login" method="POST">
+        <input type="hidden" id="id" name="id" value="{{id}}" />
+        <input type="text" id="token" name="token" />
+        <br/>
+        <br/>
+        <input class="btn btn-primary btn-lg" role="button" type="submit" value="Login" />
+      </form>
+    </div>
+  </body>
+</html>

--- a/cli-token.html
+++ b/cli-token.html
@@ -25,7 +25,7 @@
       <p>Type in the CLI token</p>
       <form action="/cli-token-login" method="POST">
         <input type="hidden" id="id" name="id" value="{{id}}" />
-        <input type="text" id="token" name="token" />
+        <input class="form-control" type="text" id="token" name="token" required />
         <br/>
         <br/>
         <input class="btn btn-primary btn-lg" role="button" type="submit" value="Login" />

--- a/revoke.html
+++ b/revoke.html
@@ -24,7 +24,7 @@
 
       <p>Type in the AuthID to revoke</p>
       <form action="/revoked" method="POST">
-        <input type="text" id="authid" name="authid" />
+        <input class="form-control" type="text" id="authid" name="authid" required />
         <br/>
         <br/>
         <input class="btn btn-primary btn-lg" role="button" type="submit" value="Revoke AuthID" />

--- a/settings.py
+++ b/settings.py
@@ -160,6 +160,8 @@ DROPBOX_REDIRECT_URI = OAUTH_CALLBACK_URI
 DROPBOX_AUTH_URL = 'https://api.dropboxapi.com/oauth2/token'
 DROPBOX_LOGIN_URL = 'https://www.dropbox.com/oauth2/authorize'
 
+JOTTACLOUD_AUTH_URL = 'https://id.jottacloud.com/auth/realms/jottacloud/protocol/openid-connect/token'
+
 LOOKUP = {
     'wl': {
         'display': 'Windows Live',
@@ -214,6 +216,7 @@ LOOKUP = {
         'auth-url': BOX_AUTH_URL,
         'login-url': BOX_LOGIN_URL
     },
+
     'dropbox': {
         'display': 'Dropbox',
         'client-id': DROPBOX_CLIENT_ID,
@@ -225,6 +228,13 @@ LOOKUP = {
         'no-state-for-token-request': True,
         # Dropbox is a little picky
         'no-redirect_uri-for-refresh-request': True
+    },
+
+    'jottacloud': {
+        'display': 'Jottacloud',
+        'client-id': "jottacli",
+        'auth-url': JOTTACLOUD_AUTH_URL,
+        'cli-token': True
     }
 }
 
@@ -324,6 +334,13 @@ SERVICES = [
         'scope': 'files.content.write files.content.read files.metadata.read files.metadata.write',
         'extraurl': 'token_access_type=offline',
         'servicelink': 'https://dropbox.com'
+    },
+    {
+        'display': 'Jottacloud',
+        'type': 'jottacloud',
+        'id': 'jottacloud',
+        'scope': 'openid offline_access',
+        'servicelink': 'https://jottacloud.com'
     }
 ]
 


### PR DESCRIPTION
Jottacloud used to support basic username/password authentication, but this was recently discontinued, while re-enabled for a limited time until June 1st 2022 after request from Duplicati users.

The new authentication in Jottacloud is based on OAuth and OpenID Connect. It does not use regular OAuth workflow, with redirect to login with callback etc. Instead, users have to manually log in to the official web gui and generate what they call a "Personal Login token" ("Generate a personal login token to log in to the Jottacloud Command-Line Tool"). This single-use token contains a username and password that can then be used as basic authentication to request a real OAuth token.

This PR adds Jottacloud as a provider. The login button leads to a new page showing a simple input box for the user to manually enter a "Personal Login Token". This is then used to request a OAuth token. Finally this is hooked into the same logic as the existing providers: Saving the token, generate authid, show the logged-in page.

Some question marks:

- I have called it "CLI Token" in the code, currently. Not sure if that is the best name for it... OpenID has something called "ID Token", but I can't really get it to match what the Jottacloud token contains. Other services have something called "Personal Access Token". I ended up naming it "CLI Token" to avoid the confusion of using some name from a standard that is not really followed.

- I was a bit unsure about the fetch token logic; is it correct to do the following in the CliTokenLoginHandler:
   ```
   fetchtoken = dbmodel.create_fetch_token(resp)

   # If this was part of a polling request, signal completion
   dbmodel.update_fetch_token(fetchtoken, authid)
   ```

- What is the significance of the user_id? It is not part of the token returned from Jottacloud, so it will be stored as N/A in oauth service. What is the effect of this? We do have the real username included in the login token, so we could use that if it is beneficial in any way..

- Developer tested, but more real user/beta-testing would be nice (was asked for in forum, but not sure if anyone actually did the effort). First of all I have done manual testing of the web gui / rest api of the service itself. Then @jthall put a lot of effort into testing it with Duplicati, as discussed in the [issue](https://github.com/duplicati/duplicati/issues/4697), successfully (after a couple of patches, mentioned in additional comments to this pr) running Duplicati against the oauth service running in a local python environment. Later, also described in [comment](https://github.com/duplicati/duplicati/issues/4697#issuecomment-1101802132) on the issue, it was deployed to Google App Engine (at a custom/unofficial url) and then tested with Duplicati connecting to it, which also seem to work fine.

See:
- https://github.com/duplicati/duplicati/issues/4697
- https://forum.duplicati.com/t/jottacloud-error-401-unauthorized/3929