### PR TITLE
CLI Token / Jottacloud follow up

### DIFF
--- a/cli-token.html
+++ b/cli-token.html
@@ -25,6 +25,7 @@
       <p>Type in the CLI token</p>
       <form action="/cli-token-login" method="POST">
         <input type="hidden" id="id" name="id" value="{{id}}" />
+        <input type="hidden" id="tokenversion" name="tokenversion" value="{{tokenversion}}" />
         <input class="form-control" type="text" id="token" name="token" required />
         <br/>
         <br/>

--- a/cli-token.html
+++ b/cli-token.html
@@ -25,6 +25,7 @@
       <p>Type in the CLI token</p>
       <form action="/cli-token-login" method="POST">
         <input type="hidden" id="id" name="id" value="{{id}}" />
+        <input type="hidden" id="fetchtoken" name="fetchtoken" value="{{fetchtoken}}" />
         <input type="hidden" id="tokenversion" name="tokenversion" value="{{tokenversion}}" />
         <input class="form-control" type="text" id="token" name="token" required />
         <br/>

--- a/main.py
+++ b/main.py
@@ -169,8 +169,9 @@ class IndexHandler(webapp2.RequestHandler):
                 link = '/cli-token?id=' + n['id']
             else:
                 link = '/login?id=' + n['id']
-                if self.request.get('token', None) is not None:
-                    link += '&token=' + self.request.get('token')
+
+            if self.request.get('token', None) is not None:
+                link += '&token=' + self.request.get('token')
 
             if tokenversion is not None:
                 link += '&tokenversion=' + str(tokenversion)
@@ -401,6 +402,7 @@ class CliTokenHandler(webapp2.RequestHandler):
             'appname': settings.APP_NAME,
             'longappname': settings.SERVICE_DISPLAYNAME,
             'id': provider['id'],
+            'fetchtoken':  self.request.get('token', ''),
             'tokenversion': self.request.get('tokenversion', '')
         }
 
@@ -418,6 +420,8 @@ class CliTokenLoginHandler(webapp2.RequestHandler):
             id = self.request.POST.get('id')
             provider, service = find_provider_and_service(id)
             display = provider['display']
+
+            fetchtoken = self.request.POST.get('fetchtoken', None)
 
             tokenversion = None
             try:
@@ -464,7 +468,6 @@ class CliTokenLoginHandler(webapp2.RequestHandler):
                     raise Exception(error)
 
                 authid = 'v2:' + id + ':' + resp['refresh_token']
-                fetchtoken = dbmodel.create_fetch_token(resp)
                 dbmodel.update_fetch_token(fetchtoken, authid)
 
                 # Report results to the user
@@ -483,8 +486,6 @@ class CliTokenLoginHandler(webapp2.RequestHandler):
                 return
 
             keyid, authid = create_authtoken(id, resp)
-
-            fetchtoken = dbmodel.create_fetch_token(resp)
 
             # If this was part of a polling request, signal completion
             dbmodel.update_fetch_token(fetchtoken, authid)

--- a/settings.py
+++ b/settings.py
@@ -234,7 +234,8 @@ LOOKUP = {
         'display': 'Jottacloud',
         'client-id': "jottacli",
         'auth-url': JOTTACLOUD_AUTH_URL,
-        'cli-token': True
+        'cli-token': True,
+        'refresh-token-rotation': True
     }
 }
 


### PR DESCRIPTION
Follow up from #7:
1. First commit adds support for v2 authid with cli tokens, which was simply skipped in #7.
2. Second commit disables v2 authid for providers that uses refresh token rotation, since these are not (currently) compatible, if my understanding is correct! This is related to https://github.com/duplicati/duplicati/pull/4779 which prevents "auto-upgrade" from v1 to v2 authid in Jottacloud backend of Duplicati. The current change in oauth handler would also do the same, but also prevents explicit use of v2 authids, and is a more "consistent" solution. For more background, see https://github.com/duplicati/duplicati/pull/4779.
3. Third commit corrects (hopefully) the "fetch token" handling when using cli token, enabling automatic insert of the authid back into duplicati. (This fetch token thing was something I had a question about in the original pr, but never got an answer).